### PR TITLE
prevent autostart failure

### DIFF
--- a/get-rinetd.sh
+++ b/get-rinetd.sh
@@ -38,6 +38,7 @@ Documentation=https://github.com/linhua55/lkl_study
 [Service]
 ExecStart=/usr/bin/rinetd-bbr -f -c /etc/rinetd-bbr.conf raw ${IFACE}
 Restart=always
+User=root
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On one of my machines the demon service will fail on every reboot, with errors:
`systemd[1]: start request repeated too quickly`
With this fix, it's working fine.